### PR TITLE
Update pom.xml to change repository URLs from spring-jpa-dynamic-quer…

### DIFF
--- a/spring-data-dynamic-query-core/pom.xml
+++ b/spring-data-dynamic-query-core/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     <name>Spring Data Dynamic Query Core</name>
     <description>Spring Data Dynamic Query Core</description>
-    <url>https://github.com/tdilber/spring-jpa-dynamic-query</url>
+    <url>https://github.com/tdilber/spring-data-dynamic-query</url>
 
     <licenses>
         <license>
@@ -34,9 +34,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/tdilber/spring-jpa-dynamic-query.git</connection>
-        <developerConnection>scm:git:ssh://github.com:tdilber/spring-jpa-dynamic-query.git</developerConnection>
-        <url>http://github.com/tdilber/spring-jpa-dynamic-query/tree/master</url>
+        <connection>scm:git:git://github.com/tdilber/spring-data-dynamic-query.git</connection>
+        <developerConnection>scm:git:ssh://github.com:tdilber/spring-data-dynamic-query.git</developerConnection>
+        <url>http://github.com/tdilber/spring-data-dynamic-query/tree/master</url>
     </scm>
 
 

--- a/spring-data-elasticsearch-dynamic-query/pom.xml
+++ b/spring-data-elasticsearch-dynamic-query/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     <name>Spring Data Elasticsearch Dynamic Query</name>
     <description>Spring Data Elasticsearch Dynamic Query (JDQ) Project</description>
-    <url>https://github.com/tdilber/spring-jpa-dynamic-query</url>
+    <url>https://github.com/tdilber/spring-data-dynamic-query</url>
 
     <licenses>
         <license>
@@ -34,9 +34,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/tdilber/spring-jpa-dynamic-query.git</connection>
-        <developerConnection>scm:git:ssh://github.com:tdilber/spring-jpa-dynamic-query.git</developerConnection>
-        <url>http://github.com/tdilber/spring-jpa-dynamic-query/tree/master</url>
+        <connection>scm:git:git://github.com/tdilber/spring-data-dynamic-query.git</connection>
+        <developerConnection>scm:git:ssh://github.com:tdilber/spring-data-dynamic-query.git</developerConnection>
+        <url>http://github.com/tdilber/spring-data-dynamic-query/tree/master</url>
     </scm>
 
 

--- a/spring-data-jpa-dynamic-query/pom.xml
+++ b/spring-data-jpa-dynamic-query/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     <name>Spring Data Jpa Dynamic Query</name>
     <description>Spring Data Jpa Dynamic Query (JDQ) Project</description>
-    <url>https://github.com/tdilber/spring-jpa-dynamic-query</url>
+    <url>https://github.com/tdilber/spring-data-dynamic-query</url>
 
     <licenses>
         <license>
@@ -34,9 +34,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/tdilber/spring-jpa-dynamic-query.git</connection>
-        <developerConnection>scm:git:ssh://github.com:tdilber/spring-jpa-dynamic-query.git</developerConnection>
-        <url>http://github.com/tdilber/spring-jpa-dynamic-query/tree/master</url>
+        <connection>scm:git:git://github.com/tdilber/spring-data-dynamic-query.git</connection>
+        <developerConnection>scm:git:ssh://github.com:tdilber/spring-data-dynamic-query.git</developerConnection>
+        <url>http://github.com/tdilber/spring-data-dynamic-query/tree/master</url>
     </scm>
 
 

--- a/spring-data-mongodb-dynamic-query/pom.xml
+++ b/spring-data-mongodb-dynamic-query/pom.xml
@@ -17,7 +17,7 @@
     <packaging>jar</packaging>
     <name>Spring Data MongoDB Dynamic Query</name>
     <description>Spring Data MongoDB Dynamic Query (JDQ) Project</description>
-    <url>https://github.com/tdilber/spring-jpa-dynamic-query</url>
+    <url>https://github.com/tdilber/spring-data-dynamic-query</url>
 
     <licenses>
         <license>
@@ -34,9 +34,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/tdilber/spring-jpa-dynamic-query.git</connection>
-        <developerConnection>scm:git:ssh://github.com:tdilber/spring-jpa-dynamic-query.git</developerConnection>
-        <url>http://github.com/tdilber/spring-jpa-dynamic-query/tree/master</url>
+        <connection>scm:git:git://github.com/tdilber/spring-data-dynamic-query.git</connection>
+        <developerConnection>scm:git:ssh://github.com:tdilber/spring-data-dynamic-query.git</developerConnection>
+        <url>http://github.com/tdilber/spring-data-dynamic-query/tree/master</url>
     </scm>
 
 


### PR DESCRIPTION
…y to spring-data-dynamic-query

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update project and SCM URLs in all module POMs to point to spring-data-dynamic-query repository.
> 
> - **Build/metadata**:
>   - Update project `url` and `scm` (`connection`, `developerConnection`, `url`) to the new repo across module POMs:
>     - `spring-data-dynamic-query-core/pom.xml`
>     - `spring-data-jpa-dynamic-query/pom.xml`
>     - `spring-data-mongodb-dynamic-query/pom.xml`
>     - `spring-data-elasticsearch-dynamic-query/pom.xml`
>   - All now point to `https://github.com/tdilber/spring-data-dynamic-query`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 602d7cf68067386bc30dad004cf38baf6d22af54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->